### PR TITLE
Dice command

### DIFF
--- a/commands/dice.js
+++ b/commands/dice.js
@@ -1,0 +1,18 @@
+module.exports = {
+    name: 'dice',
+    args: false,
+    guildOnly: false, // Specify if the command can only be used in guilds
+    aliases: [], // Aliases for the command
+    help: '!dice <amount of sides>; Rolls a dice with x amount of sides. Default of 6. DM', // Help information to show
+    restricted: [], // Options: discord ID, role ID, role Name
+    execute(message, args, config) {
+        message.channel.startTyping();
+
+        // Do the math, pick an inclusive rounded random number between 1 and 6 (default) or a specified number
+        const sides = args[0] || 6;
+        const sideRolled = Math.round(Math.random() * (sides - 1) + 1);
+
+        message.channel.send(sideRolled);
+        message.channel.stopTyping();
+    },
+};

--- a/commands/dice.js
+++ b/commands/dice.js
@@ -5,14 +5,26 @@ module.exports = {
     aliases: [], // Aliases for the command
     help: '!dice <amount of sides>; Rolls a dice with x amount of sides. Default of 6. DM', // Help information to show
     restricted: [], // Options: discord ID, role ID, role Name
-    execute(message, args, config) {
+    async execute(message, args, config) {
         message.channel.startTyping();
 
-        // Do the math, pick an inclusive rounded random number between 1 and 6 (default) or a specified number
-        const sides = args[0] || 6;
-        const sideRolled = Math.round(Math.random() * (sides - 1) + 1);
+        let requestedSides = 6;
+        const intParsedInput = parseInt(args[0]);
 
-        message.channel.send(sideRolled);
+        if (args[0] != undefined) {
+            if (Number.isInteger(intParsedInput) && intParsedInput > 0) {
+                requestedSides = intParsedInput;
+            }
+            else {
+                message.channel.stopTyping();
+                return message.channel.send('Incorrect argument');
+            }
+        }
+
+        // Do the math, pick an inclusive rounded random number between 1 and 6 (default) or a specified number
+        const sideRolled = Math.round(Math.random() * (requestedSides - 1) + 1);
+
         message.channel.stopTyping();
+        message.channel.send(`You rolled side **${sideRolled}** out of **${requestedSides}** sides`);
     },
 };


### PR DESCRIPTION
Add the dice command to the bot. Allows a higher than 0 integer as argument that is parsed as an integer (cut off at decimal).
Has a default value of 6 to simulate a standard die.
Closes #4 
**Example image:**
![image](https://user-images.githubusercontent.com/22982712/117470493-299b6f00-af57-11eb-86d8-97585c17ea53.png)
