### PR TITLE
Fix calendar recurrance exclusions

### DIFF
--- a/scripts/calendar.js
+++ b/scripts/calendar.js
@@ -202,19 +202,19 @@ function getRecurringEvents(vevent, startDate, endDate) {
 
     const excludeDates = new Set(Object.values(vevent.exdate || [])
         // An array of Dates with a tz field.
-        .map(date => DateTimeInTZ(date, date.tz)));
+        .map(date => date.getTime()));
 
     // The dates returned by the rrule will be in the local timezone.
     // We're working in UTC, so attach the local timezone so that they
     // can be converted to UTC along with everything else.
     // An array of Date()s without a tz field, but in the dtstart's timezone
     const recurrenceDates = new Set(vevent.rrule.between(startDate, endDate, true)
-        .map(date => fromRRuleDate(date, vevent.start.tz, vevent.start))
-        .filter(e => !excludeDates.has(e)));
+        .filter(e => !excludeDates.has(e.getTime()))
+        .map(date => fromRRuleDate(date, vevent.start.tz, vevent.start)));
 
     for (const [d, event] of Object.entries(vevent.recurrences || [])) {
         const date = new Date(d);
-        if (date >= startDate && date <= endDate && !excludeDates.has(d)) {
+        if (date >= startDate && date <= endDate && !excludeDates.has(date.getTime())) {
             recurrenceDates.delete(d);
             recurrenceEvents.push(event);
         }

--- a/scripts/calendar.js
+++ b/scripts/calendar.js
@@ -209,20 +209,20 @@ function getRecurringEvents(vevent, startDate, endDate) {
     // can be converted to UTC along with everything else.
     // An array of Date()s without a tz field, but in the dtstart's timezone
     const recurrenceDates = new Set(vevent.rrule.between(startDate, endDate, true)
-        .filter(e => !excludeDates.has(e.getTime()))
-        .map(date => fromRRuleDate(date, vevent.start.tz, vevent.start)));
+        .map(e => e.getTime())
+        .filter(e => !excludeDates.has(e)));
 
-    for (const [d, event] of Object.entries(vevent.recurrences || [])) {
-        const date = new Date(d);
-        if (date >= startDate && date <= endDate && !excludeDates.has(date.getTime())) {
-            recurrenceDates.delete(d);
+    for (const event of Object.values(vevent.recurrences || [])) {
+        const date = event.start.getTime();
+        if (date >= startDate.getTime() && date <= endDate.getTime() && !excludeDates.has(date)) {
+            recurrenceDates.delete(date);
             recurrenceEvents.push(event);
         }
     }
 
     recurrenceDates.forEach(d => {
         const recEvent = Object.assign({}, vevent);
-        recEvent.start = d;
+        recEvent.start = fromRRuleDate(new Date(d), vevent.start.tz, vevent.start);
         recEvent.end = new Date(d + (new Date(vevent.end).getTime() - new Date(vevent.start).getTime()));
         recurrenceEvents.push(recEvent);
     });


### PR DESCRIPTION
fixes #16 

2 issues here:
ex dates which are created when you delete a single event in a set of recurring events weren't being applied due to bad date comparisons.
Also due to bad date comparisons, event 'recurrences' which are used to override properties for a particular recurring event weren't removing the original event as they should have been.