### PR TITLE
Workaround incorrect event time display.

### DIFF
--- a/scripts/calendar.js
+++ b/scripts/calendar.js
@@ -122,7 +122,7 @@ class Calendar {
 
         outEvents
             .map(event => {
-                event.start = this.timezones.localiseTime(event.start, event.start.tz, event.start.inTzDate);
+                event.start = this.timezones.localiseTime(event.start, event.start.tz, event.start);
                 return event;
             });
 


### PR DESCRIPTION
 Workaround for event times in the calendar displaying incorrect time.
This isn't a proper solution to the issue, but will fix the problem until DST resumes (whereupon it will break again unless fixed)